### PR TITLE
Fix types not being published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "worker"
   ],
   "files": [
-    "dist"
+    "dist",
+    "./types.d.ts"
   ],
   "main": "./dist/index.commonjs2.js",
   "browser": "./dist/index.window.js",


### PR DESCRIPTION
<!-- Describe your Pull Request -->

## Current Behavior

`package.json` is published and points to `./types.d.ts` for types.

However, that file is not included in the published contents: https://unpkg.com/twilio-taskrouter@0.5.1/types.d.ts

## Expected Behavior

That file is included in the published contents and repos are able to use the types.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
