### PR TITLE
Adds axios as a dependency instead of a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "url": "https://github.com/twilio/twilio-taskrouter.js.git"
   },
   "dependencies": {
+    "axios": "^0.21.2",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.5",
     "loglevel": "^1.4.1",
@@ -66,7 +67,6 @@
     "@types/express": "^4.17.7",
     "@types/qs": "^6.9.4",
     "async-test-tools": "^1.0.7",
-    "axios": "^0.21.2",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.3",
     "chai": "^4.1.2",


### PR DESCRIPTION
Production builds with next.js fail to find `axios` module because it's defined as a dev dependency but is needed in https://github.com/twilio/twilio-taskrouter.js/blob/master/lib/util/Request.js#L29

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
